### PR TITLE
Add mermaid flowchart to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ This repository serves to reproduce the workflow of Conor's MSc thesis.
 
 # EXCITED workflow
 
-The following flowchart lays out the workflow of EXCITED. Two models are trained, the first one on (hourly)
+The following flowchart lays out the workflow of EXCITED:
+
 ```mermaid
 graph TD;
     monthlymodel(Monthly ML model);


### PR DESCRIPTION
I used [mermaid](https://mermaid.live/) to create a flowchart, and added it to the main readme.

With the [rich diff](https://github.com/EXCITED-CO2/scratch/pull/21/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) you can see the resulting flowchart.
